### PR TITLE
Added PhysicsTimescale

### DIFF
--- a/Assets/Prefabs/World/SceneEssentials.prefab
+++ b/Assets/Prefabs/World/SceneEssentials.prefab
@@ -218,6 +218,7 @@ GameObject:
   - component: {fileID: 2177332109817843740}
   - component: {fileID: 3998792855193114729}
   - component: {fileID: 1506909236767924893}
+  - component: {fileID: 5128374263377815577}
   m_Layer: 9
   m_Name: SceneEssentials
   m_TagString: Untagged
@@ -338,7 +339,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   stepFrames: 0
   DebugBreak: 0
+  _currentTimeScale: 1
   timeAcceleration: 0.45
+--- !u!114 &5128374263377815577
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4674599469190334978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9065d7ed2820f654cb1db8ae456ce6fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4893449854813629646
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Core/PhysicsTimescale.cs
+++ b/Assets/Scripts/Core/PhysicsTimescale.cs
@@ -7,26 +7,29 @@ namespace Core
     public class PhysicsTimescale : MonoBehaviour
     {
         private float _timer = 0;
+		private float _physTimePassed = 0;
 		
 		private void Awake() {
-			Physics.simulationMode = SimulationMode.Script;
+			Physics2D.simulationMode = SimulationMode2D.Script;
 		}
 		
 		private void OnEnable() {
-			Physics.simulationMode = SimulationMode.Script;
+			Physics2D.simulationMode = SimulationMode2D.Script;
 		}
 		
 		private void OnDisable() {
-			Physics.simulationMode = SimulationMode.FixedUpdate;
+			Physics2D.simulationMode = SimulationMode2D.FixedUpdate;
 		}
 		
-		private void Update() {
+		private void FixedUpdate() {
 			_timer += Game.TimeManager.DeltaTime;
 			// Unity recommends simulating physics in intervals of Time.fixedDeltaTime for stability.
 			while (_timer >= Time.fixedDeltaTime)
 			{
 				_timer -= Time.fixedDeltaTime;
-                Physics.Simulate(Time.fixedDeltaTime);
+				_physTimePassed += Time.fixedDeltaTime;
+				Debug.Log(_physTimePassed);
+                Physics2D.Simulate(Time.fixedDeltaTime);
 			}
 		}
     }

--- a/Assets/Scripts/Core/PhysicsTimescale.cs
+++ b/Assets/Scripts/Core/PhysicsTimescale.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using System;
+using ASK.Core;
+
+namespace Core
+{
+    public class PhysicsTimescale : MonoBehaviour
+    {
+        private float _timer = 0;
+		
+		private void Awake() {
+			Physics.simulationMode = SimulationMode.Script;
+		}
+		
+		private void OnEnable() {
+			Physics.simulationMode = SimulationMode.Script;
+		}
+		
+		private void OnDisable() {
+			Physics.simulationMode = SimulationMode.FixedUpdate;
+		}
+		
+		private void Update() {
+			_timer += Game.TimeManager.DeltaTime;
+			// Unity recommends simulating physics in intervals of Time.fixedDeltaTime for stability.
+			while (_timer >= Time.fixedDeltaTime)
+			{
+				_timer -= Time.fixedDeltaTime;
+                Physics.Simulate(Time.fixedDeltaTime);
+			}
+		}
+    }
+}


### PR DESCRIPTION
My understanding is that objects which use Unity's physics system do not get affected by the timescale, which mainly includes broken parts of objects. It is was hard for me to observe this when testing, but I am pretty sure these are _NOT_ affected (meaning the code doesn't work). 


I am pushing this for now since I'm not really sure why it doesn't work (the manual simulation code is working as expected).